### PR TITLE
statically linked metrics-server

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,25 +7,22 @@ platform:
 
 steps:
 - name: build
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - sleep 20
-  - TAG=${DRONE_TAG} make
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG}
 
-- name: push
-  image: rancher/hardened-build-base:v1.14.2-amd64
+- name: publish
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - TAG=${DRONE_TAG} make image-push
+  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
   environment:
     DOCKER_USERNAME:
       from_secret: docker_username
@@ -36,26 +33,12 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
-  - TAG=${DRONE_TAG} make image-scan
-  when:
-    event:
-    - tag
-
-- name: manifest
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-  - name: dockersock
-    path: /var/run
-  commands:
-  - TAG=${DRONE_TAG} make image-manifest
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG} image-scan
 
 services:
 - name: docker
@@ -66,5 +49,5 @@ services:
     path: /var/run
 
 volumes:
-  - name: dockersock
-    temp: {}
+- name: dockersock
+  temp: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,43 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.14.2-amd64
-
+ARG GO_IMAGE=rancher/hardened-build-base:v1.15.2b5
 FROM ${UBI_IMAGE} as ubi
-
 FROM ${GO_IMAGE} as builder
-ARG TAG="" 
-RUN apt update     && \ 
-    apt upgrade -y && \ 
-    apt install -y ca-certificates git
-
-RUN git clone --depth=1 https://github.com/kubernetes-sigs/metrics-server.git $GOPATH/src/github.com/kubernetes-sigs/metrics-server
-RUN mkdir -p $GOPATH/src/github.com                                                           && \
-    cd $GOPATH/src/github.com/kubernetes-sigs/metrics-server                                  && \
-    git fetch --all --tags --prune                                                            && \
-    git checkout tags/${TAG} -b ${TAG}                                                        && \
-    cp -ar $GOPATH/src/github.com/kubernetes-sigs $GOPATH/src/github.com/kubernetes-incubator && \
-    CGO_ENABLED=1 make all
+# setup required packages
+RUN set -x \
+ && apk --no-cache add \
+    file \
+    gcc \
+    git \
+    libselinux-dev \
+    libseccomp-dev \
+    make
+# setup the build
+ARG PKG="github.com/kubernetes-incubator/metrics-server"
+ARG SRC="github.com/kubernetes-sigs/metrics-server"
+ARG TAG="v0.3.6"
+RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
+WORKDIR $GOPATH/src/${PKG}
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+RUN go run vendor/k8s.io/kube-openapi/cmd/openapi-gen/openapi-gen.go --logtostderr \
+    -i k8s.io/metrics/pkg/apis/metrics/v1beta1,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/version \
+    -p ${PKG}/pkg/generated/openapi/ \
+    -O zz_generated.openapi \
+    -h $(pwd)/hack/boilerplate.go.txt \
+    -r /dev/null
+RUN GO_LDFLAGS="-linkmode=external \
+    -X ${PKG}/pkg/version.Version=${TAG} \
+    -X ${PKG}/pkg/version.gitCommit=$(git rev-parse HEAD) \
+    -X ${PKG}/pkg/version.gitTreeState=clean \
+    " \
+    go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/metrics-server ./cmd/metrics-server
+RUN go-assert-static.sh bin/*
+RUN go-assert-boring.sh bin/*
+RUN install -s bin/* /usr/local/bin
+RUN metrics-server --help
 
 FROM ubi
-ARG ARCH=amd64
-
-COPY --from=builder /go/src/github.com/kubernetes-sigs/metrics-server/_output/${ARCH}/metrics-server /
-
+RUN microdnf update -y && \
+    rm -rf /var/cache/yum
+COPY --from=builder /usr/local/bin/metrics-server /
+ENTRYPOINT ["/metrics-server"]


### PR DESCRIPTION
Leverage new alpine-based rancher/hardened-build-base (goboring built on
alpine) while matching the upstream version of go to compile with. Also
assert everything is statically linked and assert presence of goboring
symbols prior to install-with-strip.

Addresses rancher/rke2#335
