### PR TITLE
Bump metrics server version to v0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x && \
 # setup the build
 ARG PKG="github.com/kubernetes-incubator/metrics-server"
 ARG SRC="github.com/kubernetes-sigs/metrics-server"
-ARG TAG="v0.6.4"
+ARG TAG=v0.7.0
 ARG ARCH="amd64"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ORG ?= rancher
 # but still refers internally to github.com/kubernetes-incubator/metrics-server packages
 PKG ?= github.com/kubernetes-incubator/metrics-server
 SRC ?= github.com/kubernetes-sigs/metrics-server
-TAG ?= v0.6.4$(BUILD_META)
+TAG ?= v0.7.0
 
 ifneq ($(DRONE_TAG),)
 	TAG := $(DRONE_TAG)

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Build
 
 ```sh
-TAG=v0.5.2 make
+TAG=v0.7.0 make
 ```


### PR DESCRIPTION



<Actions>
    <action id="68d2a5cb36c23a2252f1eb0ee726bf5f5559442fe909b674cf31fe4390e7566d">
        <h3>Update metrics server version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest metrics server version in Dockerfile</summary>
            <p>changed lines [17] of file &#34;/tmp/updatecli/github/rancher/image-build-k8s-metrics-server/Dockerfile&#34;</p>
            <details>
                <summary>v0.7.0</summary>
                <pre>&#xA;Release published on the 2024-01-23 15:11:54 +0000 UTC at the url https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.0&#xA;&#xA;## Installation&#xD;&#xA;&#xD;&#xA;kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.7.0/components.yaml&#xD;&#xA;&#xD;&#xA;## Changes since v0.6.4&#xD;&#xA;&#xD;&#xA;Logging flags that are klog specific (`--log-dir`, `--log-file`, `--logtostderr`, `--alsologtostderr`, `--one-output`, `--stderrthreshold`, `--log-file-max-size`, `--skip-log-headers`, `--add-dir-header`, `--skip-headers`, `--log-backtrace-at`) were deprecated in v0.6.1 and are now **removed**.&#xD;&#xA;&#xD;&#xA;### Improvements&#xD;&#xA;&#xD;&#xA;- Support producing logs in JSON format (@yangjunmyfm192085)&#xD;&#xA;- Introduce `--kubelet-request-timeout` CLI flag to customize the timeout of requests to kubelet (@yangjunmyfm192085)&#xD;&#xA;- Add the ability to exclude nodes by labels via the `--node-selector` flag (@yangjunmyfm192085)&#xD;&#xA;- Disable DWARF generation when compiling the binary to reduce its size (@mattmoor)&#xD;&#xA;- Support modifying the metric collection path on nodes via the `metrics.k8s.io/resource-metrics-path` annotation on the nodes (@wzshiming)&#xD;&#xA;- Add release binaries to the Github release artifacts (@wzshiming)&#xD;&#xA;- Bump Golang to v1.21.6 and Kubernetes clients to v0.29.0&#xD;&#xA;&#xD;&#xA;### Optimizations&#xD;&#xA;&#xD;&#xA;- Remove redundant informer startup (@yangjunmyfm192085)&#xD;&#xA;&#xD;&#xA;### Fixes&#xD;&#xA;&#xD;&#xA;- Handle malformed metrics from Kubelet (@XiaoXiaoSN)&#xD;&#xA;- Handle Kernel bug leading to incorrect CPU usage data (@sleepyzhang)&#xD;&#xA;&#xD;&#xA;### Tests&#xD;&#xA;&#xD;&#xA;- Add fuzzing testing (@yangjunmyfm192085)&#xD;&#xA;- Add resource usage tests (@yangjunmyfm192085)&#xD;&#xA;- Add tests for sidecar containers (@yangjunmyfm192085)&#xD;&#xA;- Configure e2e tests to be arm &amp; darwin compatible (@josh-ferrell)&#xD;&#xA;- Test against Kubernetes 1.27, 1.28, 1.29 (@yangjunmyfm192085)&#xD;&#xA;&#xD;&#xA;### Manifests&#xD;&#xA;&#xD;&#xA;- Migrate to a base-components-overlays structure (@maxbrunet)&#xD;&#xA;- Update PodDisruptionBudget to policy/v1 (@yangjunmyfm192085)&#xD;&#xA;- Add version-specific HA manifests (@dgrisonnet)&#xD;&#xA;- Permit running metrics-server under PodSecurity restricted (@jcpunk)&#xD;&#xA;- Update autoscaling configuration to follow README recommendation (@serathius)&#xD;&#xA;- Add containerSecurityContext for addonResizer (@the-technat)&#xD;&#xA;&#xD;&#xA;### Documentations&#xD;&#xA;&#xD;&#xA;- Add new scenarios to the KNOWN_ISSUES (@serathius, @maxmetalm, @yangjunmyfm192085)&#xD;&#xA;- Document CLI flags (@serathius)&#xD;&#xA;- Document metrics-server&#39;s network requirements (@yangjunmyfm192085, @serathius)&#xD;&#xA;- Improve high-availability guidelines (@sherifabdlnaby)</pre>
            </details>
        </details>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump to latest metrics server version in Makefile</summary>
            <p>1 file(s) updated with &#34;TAG ?= v0.7.0&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
        <details id="711a6108ba2ce6ca93dd47d6817f2361db10d8ab6eec89460b2dfc2c325efabe">
            <summary>Bump to latest metrics server version in README</summary>
            <p>1 file(s) updated with &#34;TAG=v0.7.0 make&#34;:&#xA;&#x9;* README.md&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

