### PR TITLE
Use updatecli to update versions

### DIFF
--- a/updatecli/updatecli.d/updatebuildbase.yaml
+++ b/updatecli/updatecli.d/updatebuildbase.yaml
@@ -1,0 +1,78 @@
+---
+name: "Update build base version" 
+
+sources:
+  gomod:
+    name: Get latest Golang version based on go.mod
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/go.mod
+      matchpattern: 'go ([0-9]+\.[0-9]+)'
+    transformers:
+      - trimprefix: "go "
+
+  buildbase:
+   name: Get build base version
+   kind: githubrelease
+   dependson:
+     - "gomod"
+   spec:
+     owner: rancher
+     repository: image-build-base
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: regex
+       pattern: '{{ source "gomod"}}\.\S+'
+
+targets:
+  dockerfile:
+    name: "Bump to latest build base version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: buildbase
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: "GO_IMAGE"
+    transformers:
+      - addprefix: "rancher/hardened-build-base:"
+
+  drone:
+    name: "Bump to latest build base version in Dockerfile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: .drone.yml
+      matchpattern: '(?m)^  image: rancher/hardened-build-base:(.*)'
+      replacepattern: '  image: rancher/hardened-build-base:{{ source "buildbase" }}'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump build base version to {{ source "buildbase" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default
+

--- a/updatecli/updatecli.d/updatemetricsserver.yaml
+++ b/updatecli/updatecli.d/updatemetricsserver.yaml
@@ -1,0 +1,66 @@
+---
+name: "Update metrics server version" 
+
+sources:
+ metricsserver:
+   name: Get metrics-server version
+   kind: githubrelease
+   spec:
+     owner: kubernetes-sigs
+     repository: metrics-server
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: semver
+       # pattern accepts any semver constraint
+       pattern: "*"
+
+targets:
+  dockerfile:
+    name: "Bump to latest metrics server version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: metricsserver
+    spec:
+      file: "Dockerfile"
+      instruction:
+        keyword: "ARG"
+        matcher: "TAG"
+
+  makefile:
+    name: "Bump to latest metrics server version in Makefile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: '(?m)^TAG \?\= (.*)'
+      replacepattern: 'TAG ?= {{ source "metricsserver" }}$$(BUILD_META)'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump metrics server version to {{ source "metricsserver" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default
+

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,3 +3,6 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
+  repository: "image-build-k8s-metrics-server"
+  branch: "master"
+  owner: "rancher"


### PR DESCRIPTION
This PR automates the version bump of:
* metric-server (example: https://github.com/rancher/image-build-k8s-metrics-server/pull/33)
* hardened-build-base: (example: https://github.com/rancher/image-build-k8s-metrics-server/pull/30)