### PR TITLE
Fix metrics-server build for v0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@ RUN set -x && \
 # setup the build
 ARG PKG="github.com/kubernetes-incubator/metrics-server"
 ARG SRC="github.com/kubernetes-sigs/metrics-server"
-ARG TAG="v0.6.4"
+ARG TAG="v0.7.0"
 ARG ARCH="amd64"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
-RUN go install -mod=readonly k8s.io/kube-openapi/cmd/openapi-gen && \
+RUN go install -mod=readonly -modfile=scripts/go.mod k8s.io/kube-openapi/cmd/openapi-gen && \
     ${GOPATH}/bin/openapi-gen --logtostderr \
     -i k8s.io/metrics/pkg/apis/metrics/v1beta1,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/version \
     -p ${PKG}/pkg/generated/openapi/ \

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@ ORG ?= rancher
 # but still refers internally to github.com/kubernetes-incubator/metrics-server packages
 PKG ?= github.com/kubernetes-incubator/metrics-server
 SRC ?= github.com/kubernetes-sigs/metrics-server
-TAG ?= v0.6.4$(BUILD_META)
+TAG ?= v0.7.0$(BUILD_META)
 
 ifneq ($(DRONE_TAG),)
 	TAG := $(DRONE_TAG)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
-	$(error TAG needs to end with build metadata: $(BUILD_META))
+$(error TAG needs to end with build metadata: $(BUILD_META))
 endif
 
 .PHONY: image-build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
 # rancher/hardened-k8s-metrics-server
-
-## Build
-
-```sh
-TAG=v0.5.2 make
-```


### PR DESCRIPTION
This PR does three things:
1 - Upgrades to v0.7.0
2 - Adds `-modfile=scripts/go.mod ` which is included in upstream too. Otherwise v0.7.0 fails to build
3 - Fixes the Makefile. If you add tabs to the Makefile the interpreter things it is a recipe and thus, if we follow the README (which is wrong because it does not add a (BUILD) metadata, we get the error:
```
*** recipe commences before first target.  Stop.
```
As the README has been wrong for a long time and nobody realized, it feels like we don't need that instruction. Anyway, the Makefile is pretty simple and just running 'make' works