### PR TITLE
Fix updatecli after GHA migration

### DIFF
--- a/updatecli/updatecli.d/updatemetricsserver.yaml
+++ b/updatecli/updatecli.d/updatemetricsserver.yaml
@@ -37,8 +37,8 @@ targets:
     disablesourceinput: true
     spec:
       file: Makefile
-      matchpattern: '(?m)^TAG \?\= (.*)'
-      replacepattern: 'TAG ?= {{ source "metricsserver" }}$$(BUILD_META)'
+      matchpattern: '(?m)^TAG \:\= (.*)'
+      replacepattern: 'TAG := {{ source "metricsserver" }}$$(BUILD_META)'
 
 scms:
   default:


### PR DESCRIPTION
Makefile changed and now there are two TAGs. We should replace the one with ":"

```
TAG ?= ${GITHUB_ACTION_TAG}

ifeq ($(TAG),)
TAG := v0.7.1$(BUILD_META)
endif
```